### PR TITLE
Initial explain-pause-top implementation.

### DIFF
--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -1,4 +1,4 @@
-;;; explain-pause-mode.el --- try to explain emacs pauses -*- lexical-binding: t; -*-
+;;; explain-pause-mode.el --- explain emacs pauses -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2020 Lin Xu
 
@@ -26,12 +26,13 @@
 
 ;;; Commentary:
 
-;; `explain-pause-mode' is a minor mode that measures and explains when Emacs has
-;; paused doing work for a long time.  Any user input during a pause is not processed
-;; until it is complete.  So in other words, `explain-pause-mode' tries to explain
-;; sources of user latency.  When many pauses of the same kind occur, it also
-;; generates profiling reports that can be investigated immediately or sent to
-;; developers.
+;; `explain-pause-mode' is a minor mode that measures how long Emacs commands
+;; take to run. `explain-pause-top' is like 'top', but for Emacs.
+;;
+;; When a command consistently takes a long time to run, `explain-pause-mode'
+;; alerts the user and records the next time the command is slow. These "slow
+;; events" can be viewed in `explain-pause-top' and investigated immediately,
+;; or summarized to be sent to developers.
 
 ;; Please see README.md for commentary, documentation, etc. in the repository
 ;; above.
@@ -89,16 +90,35 @@ the buffer size (but you will lose the current profiles)."
          (explain-pause-profiles-clear))
   :initialize 'custom-initialize-default)
 
+(defcustom explain-pause-top-auto-refresh-interval 2
+  "How often `explain-pause-top' mode buffers refresh themselves by default.
+If this is nil, they do not automatically refresh. You can control this on a
+per buffer basis by calling `explain-pause-top-auto-refresh'."
+  :type 'integer)
+
+;; public hooks
+(defvar explain-pause-measured-command-hook nil
+  "Functions(s) to call after a command has been measured. The functions are
+called with arguments (ms, read-io-ms, command-set). Command-set is a list
+of function symbols or strings.
+
+These commands must be fast, because this hook is executed on every command,
+not just slow commands.")
+
+;; logging functions
 (defun explain--as-ms-exact (time)
   "Returns the TIME object in exact milliseconds, ignoring picoseconds."
   (-let [(high-seconds low-seconds microseconds) time]
     (+ (* (+ (* high-seconds 65536) low-seconds) 1000) (/ microseconds 1000))))
 
+(defun explain-pause--float-2-fixed (val)
+  "Turn a floating point value into a fixed 2 digit string."
+  (format "%.2f" val))
+
 (defun explain--escape-format (str)
   "Escape a string so that there are no format specifiers within it."
   (replace-regexp-in-string "%" "%%" str t t))
 
-;; logging functions
 (let ((explain--log-buffer nil))
   (defun explain--get-log-buffer ()
     "Get the explain-pause-log buffer or create it if does not exist"
@@ -341,6 +361,760 @@ changed.)"
         (setq count (1+ count))
         (puthash command-set count candidates)))))
 
+;; table functions
+;; I tried to use `tabulated-list' as well as `ewoc' but I decided to implement
+;; something myself. This list/table implements some ideas that are from react/JS
+;; like philosophies around optimizing drawing...
+;; part of it is already abstracted out into something close to reusable, but
+;; other parts are not yet.
+(cl-declaim (optimize (safety 0))) ;; don't type check
+(cl-defstruct explain-pause-top--table
+  ;; the list of entries to display, in sorted order
+  ;; to simplify list manipulation code, always have a head
+  (entries (list nil))
+  ;; the display entries bookkeeping; a list of explain-pause-top--table-display-entry
+  (display-entries (list nil))
+  ;; the sorter
+  (sorter (lambda (lhs rhs)
+            (<
+             (nth 2 lhs)
+             (nth 2 rhs))))
+  ;; the current width
+  (width 0)
+  ;; whether on next paint, we need to resize
+  (needs-resize t)
+  ;; the width of every column
+  column-widths
+  ;; the width of every header
+  header-widths
+  ;; the header titles
+  ;; TODO data-driven
+  (header-titles '("Command" "avg ms" "ms" "calls"))
+  ;; the full line format string
+  display-full-line-format
+  ;; the format strings for every column
+  display-column-formats
+  ;; the offset of every column
+  display-column-offsets
+  ;; the header-line
+  display-header-line)
+
+(cl-defstruct explain-pause-top--table-display-entry
+  begin-mark
+  item-ptr
+  prev-state
+  total-length
+  cached-strings
+  cached-string-lengths)
+
+(defun explain-pause-top--table-set-sorter (table new-sort &optional fast-flip)
+  "Change the sort function. Does not re-render.
+
+If fast-flip is set, simply reverse the entries. The new sort function
+must actually implement the reversed order, it (and sort) are just not
+called."
+  ;; skip over the head
+  (let* ((entry-ptrs (cdr (explain-pause-top--table-entries table)))
+         (sorted-ptrs (if fast-flip
+                          (reverse entry-ptrs)
+                        (sort entry-ptrs new-sort))))
+    (setf (explain-pause-top--table-entries table)
+          (cons nil sorted-ptrs))
+    (setf (explain-pause-top--table-sorter table)
+          new-sort)))
+
+(defun explain-pause-top--table-refresh (table)
+  "Refresh the table of items in the current buffer when requested. Note that
+the width cannot be 0."
+  ;; first, calculate the widths of all the columns.
+  ;; To do this, now walk through all the entries, updating their current
+  ;; items as needed, and ask them to prepare to draw.
+  ;; after, insert new, un-base-marked entries to take care of any new
+  ;; items.
+  ;; walk both the display-order and the display-entries
+  (let* ((display-order-ptr (cdr (explain-pause-top--table-entries table)))
+         (display-entries-prev (explain-pause-top--table-display-entries table))
+         (display-entries-ptr (cdr display-entries-prev))
+         (display-column-widths (explain-pause-top--table-column-widths table))
+         (column-count (length display-column-widths))
+         (requested-widths (copy-sequence
+                            (explain-pause-top--table-header-widths table)))
+         (layout-changed nil))
+
+    (while display-entries-ptr
+      (let* ((current-entry (car display-entries-ptr))
+             (to-draw-item (car display-order-ptr)))
+
+        (setf (explain-pause-top--table-display-entry-item-ptr current-entry)
+              to-draw-item)
+
+        (explain-pause-top--table-prepare-draw current-entry requested-widths))
+
+      (setq display-order-ptr (cdr display-order-ptr))
+      (setq display-entries-prev display-entries-ptr)
+      (setq display-entries-ptr (cdr display-entries-ptr)))
+
+    ;; ok, now reconcile & add new items
+    ;; prev points to the end now
+    (while display-order-ptr
+      (let* ((new-entry (make-explain-pause-top--table-display-entry
+                         :begin-mark nil
+                         :item-ptr (car display-order-ptr)
+                         :prev-state nil
+                         :total-length nil
+                         :cached-strings (make-list column-count nil)
+                         :cached-string-lengths (make-list column-count nil)))
+             (new-list-entry (list new-entry)))
+
+        (explain-pause-top--table-prepare-draw new-entry requested-widths)
+
+        ;; insert at the tail
+        (setcdr display-entries-prev new-list-entry)
+        (setq display-entries-prev new-list-entry)
+        (setq display-order-ptr (cdr display-order-ptr))))
+
+    ;; at this point, the following invariants hold:
+    ;; * every entry has a display-entry (but not all of them have begin-marks)
+    ;; * columns holds the largest requested width.
+    ;; check to see if the fixed columns have changed width, OR if our width
+    ;; changed. If so, we'll set prev-state for every entry as we paint to nil,
+    ;; to force a full refresh:
+    ;; (TODO could we only paint things "after" the first change?)
+    (when (or (not (equal (cdr display-column-widths) (cdr requested-widths)))
+              (explain-pause-top--table-needs-resize table))
+
+      ;; if they are not equal, update the header, format strings, etc.
+      (explain-pause-top--table-resize-columns table (cdr requested-widths))
+
+      (let ((header (explain-pause-top--table-display-header-line table)))
+        (setq header-line-format
+              `(:eval (explain-pause-top--generate-header-line
+                       ,header
+                       ,(length header)
+                       (window-hscroll)
+                       (- (window-total-width) 1)))))
+
+      (setf (explain-pause-top--table-needs-resize table) nil)
+      (setq layout-changed t))
+
+    ;; now, we are prepared to draw. reuse display-entries-ptr...
+    (setq display-entries-ptr
+          (cdr (explain-pause-top--table-display-entries table)))
+    (while display-entries-ptr
+      (let ((current-entry (car display-entries-ptr)))
+        (when layout-changed
+          (setf (explain-pause-top--table-display-entry-prev-state current-entry)
+                nil))
+
+        (explain-pause-top--table-draw table current-entry))
+
+      (setq display-entries-ptr (cdr display-entries-ptr)))))
+
+(defun explain-pause-top--table-item-command-overflow
+    (table column-widths command-string)
+  "Return the truncated string for command in first row, and strings for
+further lines, if needed."
+  ;; This really is not very nice, breaking multiple abstraction
+  ;; layers, but I'm really not convinced yet I want to properly
+  ;; genericize this table code
+  (let ((command-column-width (nth 0 column-widths)))
+    (if (< (length command-string)
+           command-column-width)
+        ;; it fits. return a polymorphic type because I don't want to
+        ;; make lists all the time.
+        command-string
+      ;; ok, truncate and split:
+      (let* ((table-width (explain-pause-top--table-width table))
+             (index (- command-column-width 1))
+             (first-line (concat (substring command-string 0 index) "\\"))
+             (rest-parts (seq-partition (substring command-string index)
+                                        (- table-width 3))) ;; 2 spaces + slash
+             ;; TODO probably should do this via proper ident systems...
+             (rest-lines (concat "\n  " (mapconcat #'identity rest-parts "\\\n  "))))
+        (cons first-line rest-lines)))))
+
+(defun explain-pause-top--table-draw (table item)
+  "Redraw an item within it's bounds. If the item has a begin-mark, we exist.
+If not, we're new. Move to EOB, set begin-mark. If prev-state exists, we
+should update columns. If it not set, draw the entire line at once."
+  (let* ((begin-mark (explain-pause-top--table-display-entry-begin-mark item))
+         (item-ptr (explain-pause-top--table-display-entry-item-ptr item))
+         (prev-state (explain-pause-top--table-display-entry-prev-state item))
+         (cached-strings
+          (explain-pause-top--table-display-entry-cached-strings item))
+         (column-widths
+          (explain-pause-top--table-column-widths table))
+         (total-prev-length
+          (explain-pause-top--table-display-entry-total-length item)))
+
+    (unless begin-mark
+      (setq begin-mark (point-max-marker))
+      (setf (explain-pause-top--table-display-entry-begin-mark item) begin-mark))
+
+    (cond
+     (prev-state
+      (let ((column-offsets
+             (explain-pause-top--table-display-column-offsets table))
+            (format-strings
+             (explain-pause-top--table-display-column-formats table)))
+
+        ;; cmd, again, is special cased due to overflow logic.
+        ;; this could be cleaned up and abstracted away, but I'm not sure
+        ;; I want to bother yet. cmd is item 3
+        ;; TODO data-driven
+        (unless (eq (nth 3 prev-state)
+                    (nth 3 item-ptr))
+          ;; ... but column 0
+          (let* ((command-str (nth 0 cached-strings))
+                 (command-lines (explain-pause-top--table-item-command-overflow
+                                 table column-widths command-str))
+                 (format-str (nth 0 format-strings))
+                 (first-line
+                  (if (stringp command-lines) command-lines
+                    (car command-lines)))
+                 (extra-lines
+                  (unless (stringp command-lines) (cdr command-lines)))
+                 (printed-first-line (format format-str first-line))
+                 (last-column-end (+ (nth 3 column-offsets)
+                                     (nth 3 column-widths))))
+            ;; we know offset is 0
+            (goto-char begin-mark)
+            (delete-char (length printed-first-line))
+            (insert printed-first-line)
+
+            ;; now deal with extra lines.  total-prev-length must exist. if the
+            ;; total-prev-length is > the last column end, then we already had
+            ;; extra lines; delete them, insert ours, if it exists, and update
+            ;; total-prev-lines
+            (let ((prev-extra-length (- total-prev-length last-column-end)))
+              (goto-char (+ begin-mark last-column-end))
+              (when (> prev-extra-length 0)
+                (delete-char prev-extra-length))
+              (when extra-lines
+                (insert extra-lines))
+              (let ((new-total-length (+ last-column-end (length extra-lines))))
+                (unless (eq new-total-length total-prev-length)
+                  (setf (explain-pause-top--table-display-entry-total-length item)
+                        new-total-length))))))
+
+        ;; all the rest are normal
+        ;; TODO data-driven
+        (dolist (item
+                 '((2 . 1)   ;; avg
+                   (1 . 2)   ;; ms
+                   (0 . 3))) ;; count
+          (let* ((item-index (car item))
+                 (column-index (cdr item))
+                 (old-val (nth item-index prev-state))
+                 (new-val (nth item-index item-ptr)))
+            (unless (eq old-val new-val)
+              ;; don't do these lookups unless we have to
+              (let* ((offset (nth column-index column-offsets))
+                     (format-str (nth column-index format-strings))
+                     (cached-val (nth column-index cached-strings))
+                     (new-str (format format-str cached-val)))
+                (goto-char (+ begin-mark offset))
+                (delete-char (length new-str))
+                (insert new-str)))))))
+     (t
+      ;; draw everything in one shot
+      (let* ((full-format-string
+              (explain-pause-top--table-display-full-line-format table))
+             (command-str (nth 0 cached-strings))
+             (command-lines (explain-pause-top--table-item-command-overflow
+                             table column-widths command-str))
+             (first-line
+              (if (stringp command-lines) command-lines
+                (car command-lines)))
+             (extra-lines
+              (unless (stringp command-lines) (cdr command-lines)))
+             ;; Hm. feels slow.
+             (final-string (concat
+                            (apply 'format
+                                   (cons full-format-string
+                                         (cons first-line
+                                               (cdr cached-strings))))
+                            extra-lines)))
+        ;; go to the beginning of our region
+        (goto-char begin-mark)
+
+        (when total-prev-length
+          ;; we already existed, remove the old
+          (delete-char total-prev-length))
+
+        (insert final-string)
+
+        (setf (explain-pause-top--table-display-entry-total-length item)
+              (length final-string))
+
+        (unless total-prev-length
+          ;; we didn't exist, add the newline
+          (insert "\n")))))
+
+    ;; update the prev state. this assumes no one is mutating deeply
+    (setf (explain-pause-top--table-display-entry-prev-state item)
+          (copy-sequence item-ptr))))
+
+(defun explain-pause-top--table-prepare-draw (item requested-widths)
+  "Prepare to draw an item by generating the converted strings from the values,
+and update REQUESTED-WIDTHS with their widths."
+  (let ((cached-strings
+         (explain-pause-top--table-display-entry-cached-strings item))
+        (cached-string-lengths
+         (explain-pause-top--table-display-entry-cached-string-lengths item))
+        (item-ptr (explain-pause-top--table-display-entry-item-ptr item))
+        (prev-state (explain-pause-top--table-display-entry-prev-state item)))
+
+    ;; TODO data-driven
+    (dolist (item '((3 0 explain--command-set-as-string)
+                    (2 1 explain-pause--float-2-fixed)
+                    (1 2 number-to-string)
+                    (0 3 number-to-string)))
+      (let* ((item-index (nth 0 item))
+             (column-index (nth 1 item))
+             (old-val (nth item-index prev-state))
+             (new-val (nth item-index item-ptr))
+             (column-width (nth column-index requested-widths))
+             (compare-width 0))
+
+        (if (eq old-val new-val)
+            (setq compare-width (nth column-index cached-string-lengths))
+          ;; set and update
+          (let* ((new-str (funcall (nth 2 item) new-val))
+                 (new-string-width (string-width new-str)))
+            (setf (nth column-index cached-strings) new-str)
+            (setf (nth column-index cached-string-lengths) new-string-width)
+            (setq compare-width new-string-width)))
+
+        (when (> compare-width column-width)
+          (setf (nth column-index requested-widths) compare-width))))))
+
+(defun explain-pause-top--table-find-and-insert (table item)
+  "insert item into the entries, sorted by the current sort function. If the
+item is found by the time insertion happens, return the prev item (whose cdr
+points to the item). If it is not found, return the newly added item.
+Comparison of items is by `eq'. If the new item would have been inserted at
+the exact same place as the existing item, no insertion occurs, and nil is
+returned."
+  (let* ((ptr-entry nil) ;; don't allocate it unless we absolutely need it
+         (display-order-prev (explain-pause-top--table-entries table))
+         (display-order-ptr (cdr display-order-prev))
+         (sort-function (explain-pause-top--table-sorter table))
+         (saved-dup-item-entry nil))
+
+    ;; insert and search the list at the same time
+    (catch 'inserted
+      (while display-order-ptr
+        (let ((compare-item (car display-order-ptr)))
+          ;; it is very common we only update a value without changing
+          ;; the order of the list. check for that case here, so we
+          ;; don't create objects just to throw them away in the update
+          ;; function
+          (if (eq compare-item item)
+              ;; exactly equal; we've found the previous entry
+              ;; would we have inserted the new item here?
+              (let ((next-item (cdr display-order-ptr)))
+                ;; if there is no next, then we are at the end anyway,
+                ;; and certainly we would replace ourselves
+                (when (or (not next-item)
+                           (funcall sort-function (car next-item) item))
+                  ;; yes: get outta here
+                  (throw 'inserted nil))
+                ;; otherwise, skip it
+                (setq saved-dup-item-entry display-order-prev))
+                ;; not equal - actual compare:
+            (when (funcall sort-function compare-item item)
+              ;; we can insert
+              (setq ptr-entry (list item))
+              (setcdr display-order-prev ptr-entry)
+              (setcdr ptr-entry display-order-ptr)
+              ;; finish early
+              (throw 'inserted nil)))
+
+          (setq display-order-prev display-order-ptr)
+          (setq display-order-ptr (cdr display-order-ptr))))
+
+      ;; at the end, and we didn't insert
+      (setq ptr-entry (list item))
+      (setcdr display-order-prev ptr-entry))
+
+    (or saved-dup-item-entry
+        ptr-entry)))
+
+(defun explain-pause-top--table-insert (table item)
+  "Insert an item into the entries. It will be inserted at the correct place
+with the current sort function."
+  (explain-pause-top--table-find-and-insert table item))
+
+(defun explain-pause-top--table-update (table item)
+  "Update an item in the entries. It will be moved to the correct place
+with the current sort function. It is expected that the item is `eq' to
+an already existing item in the entries."
+  (let* ((prev
+          (explain-pause-top--table-find-and-insert table item))
+         (ptr (cdr prev)))
+    ;; if prev is nil, we don't need to do anything at all.
+    (when prev
+      ;; otherwise, we have to clean up the old entry:
+      (when (eq (car prev) item)
+        ;; it was not found, and the entry returned is the newly inserted
+        ;; continue searching for the old entry:
+        (catch 'found
+          (while ptr
+            (when (eq (car ptr) item)
+              ;; prev now points to us
+              (throw 'found nil))
+            (setq prev ptr)
+            (setq ptr (cdr ptr)))))
+
+      ;; ok, splice the old one out
+      (setcdr prev (cdr ptr)))))
+
+(defun explain-pause-top--table-generate-offsets (widths)
+  "Return a list of offsets for all the columns in width."
+  (let ((offset-accum 0))
+    (mapcar
+     (lambda (width)
+       (let ((base offset-accum))
+         (setq offset-accum (+ offset-accum width))
+         base))
+     widths)))
+
+(defun explain-pause-top--table-init-header-widths (table)
+  "Initialize the header column fixed widths for TABLE. Must be run in the
+buffer it is expected to draw in."
+  (setf (explain-pause-top--table-header-widths table)
+        (mapcar #'string-width
+                (explain-pause-top--table-header-titles table))))
+
+(defun explain-pause-top--table-resize-columns (table fixed-widths)
+  "Resize the fixed columns within a table to new widths given. Does NOT
+need to be run within the current buffer, as it never runs `string-width'."
+  (let*
+      ((width (explain-pause-top--table-width table))
+       (header-titles (explain-pause-top--table-header-titles table))
+       (fixed-column-titles (cdr header-titles))
+       (total-fixed (seq-reduce #'+
+                                fixed-widths
+                                ;; account for the space between the columns
+                                (- (length fixed-column-titles) 1)))
+       ;; the beginning of the fixed base, aka the width of the fill column
+       (fill-width (- width total-fixed))
+       (column-offsets
+        (explain-pause-top--table-generate-offsets
+         (cons fill-width
+               (mapcar (lambda (width)
+                         (1+ width)) fixed-widths))))
+       ;; now generate the format strings for every column
+       (fixed-format-string-list
+        (mapcar (lambda (width)
+                  ;; ask for the column to be padded to be right
+                  ;; justified, but also to limit the total characters
+                  ;; to the same width.
+                  (format "%%%d.%ds" width width)) fixed-widths))
+       ;; now generate the fill format string; it's left justified:
+       (fill-format-string
+        (format "%%-%d.%ds" fill-width fill-width))
+       ;; now generate the full format line for use when inserting a full row
+       ;; (and header line)
+       (full-format-string (concat fill-format-string
+                                   (mapconcat #'identity
+                                              fixed-format-string-list " ")))
+       ;; now generate the header line:
+       (header-line (apply 'format (cons full-format-string header-titles))))
+
+    (setf (explain-pause-top--table-column-widths table)
+          (cons fill-width fixed-widths))
+
+    (setf (explain-pause-top--table-display-column-offsets table)
+          column-offsets)
+
+    (setf (explain-pause-top--table-display-column-formats table)
+          (cons fill-format-string fixed-format-string-list))
+
+    (setf (explain-pause-top--table-display-full-line-format table)
+          full-format-string)
+
+    (setf (explain-pause-top--table-display-header-line table) header-line)))
+
+(defun explain-pause-top--table-resize-width (table width)
+  "Resize the table by updating the width and setting the dirty width
+flag. Does not draw, nor recalculate any widths."
+  (setf (explain-pause-top--table-width table) width)
+  (setf (explain-pause-top--table-needs-resize table) t))
+
+(defun explain-pause-top--generate-header-line
+    (header header-length window-scroll window-width)
+  "Generate a truncated header line. The header scrolls with the text, and
+adds '$' when there is more header either front or end."
+  ;; TODO this should probably use the actual continuation glyph?
+  ;; TODO these really need to be test cases:
+
+  ;; text      |-------|
+
+  ;; window        |--------|
+  ;; window |-------|
+  ;; window |--------------|
+  ;; window      |---|
+  ;; window               |-------|
+  ;; window -|
+
+  ;; first, calculate the window we "should" watch over:
+  (let* ((start window-scroll)
+         (end (+ start window-width))
+
+         ;; next, if the window is outside the bounds, adjust the bounds to match
+         (bounded-start (min (max 0 start) header-length))
+         (bounded-end (min (max 0 end) header-length))
+
+         ;; next, calculate if we need dots:
+         (head-dots (> bounded-start 0))
+         (end-dots (< bounded-end header-length))
+
+         ;; the dot strings
+         (head-dot-str (when head-dots "$"))
+         (end-dot-str (when end-dots "$"))
+
+         ;; the head padding, which only applies if we've negatively scrolled
+         (head-padding (when (< start 0)
+                         (make-string (- start) ? ))))
+
+    (when head-dots
+      (if (< bounded-start header-length)
+          ;; we need dots at the front and we can move forward.
+          (setq bounded-start (1+ bounded-start))
+        ;; if the move forward would have moved the bounded start
+        ;; beyond the string, set start and end to 0 and clear the
+        ;; end dot str:
+        (setq bounded-start 0)
+        (setq bounded-end 0)
+        (setq end-dot-str nil)))
+
+    (when end-dots
+      (let ((new-end (- bounded-end 1)))
+        (if (>= new-end bounded-start)
+            ;; if we can go backwards, all's ok
+            (setq bounded-end new-end)
+          ;; if not, this means bounded-start == bounded-end,
+          ;; and we don't have space to insert a $. do nothing
+          (setq end-dot-str nil))))
+
+    (concat head-padding
+            head-dot-str
+            (substring header bounded-start bounded-end)
+            end-dot-str)))
+
+;; explain-pause-top-mode
+;; buffer-local variables that should be always private
+(defvar-local explain-pause-top--buffer-refresh-timer nil
+  "The timer for the buffer. It is nil if auto-refresh is off for that buffer.")
+
+(defvar-local explain-pause-top--buffer-refresh-interval nil
+  "The refresh interval for the buffer. It is nil if auto-refresh is off for
+that buffer.")
+
+(defvar-local explain-pause-top--buffer-window-size-changed nil
+  "The lambda hook added to `window-size-change-functions' for the buffer
+to watch for resizes.")
+
+(defvar-local explain-pause-top--buffer-table nil
+  "The table for the buffer")
+
+;; `explain-pause-top' major mode
+(define-derived-mode explain-pause-top-mode special-mode
+  "Explain Pause Top"
+  "Major mode for listing the statistics generated by explain-pause for recently
+run commands in emacs. The mode resizes the table inside the buffer to always be
+the width of the largest window viewing the buffer. Revering the buffer will
+refresh the table. The buffer initially starts with the auto refresh interval
+given in `explain-pause-top-auto-refresh-interval'. You can modify this interval
+on a per buffer basis by calling `explain-pause-top-auto-refresh'."
+  (buffer-disable-undo)
+  (setq truncate-lines t)
+  (setq buffer-read-only t)
+
+  (setq-local revert-buffer-function #'explain-pause-top--buffer-revert)
+
+  (setq-local explain-pause-top--buffer-table
+              (make-explain-pause-top--table))
+
+  (explain-pause-top--table-init-header-widths explain-pause-top--buffer-table)
+
+  (let ((this-buffer (current-buffer)))
+    (when explain-pause-top--buffer-window-size-changed
+      (remove-hook 'window-size-change-functions
+                   explain-pause-top--buffer-window-size-changed))
+
+    (setq-local explain-pause-top--buffer-window-size-changed
+                (lambda (frame)
+                  (explain-pause-top--buffer-update-width-from-windows
+                   this-buffer
+                   frame
+                   (get-buffer-window-list this-buffer))))
+
+    (explain-pause-top--pipe-commands 'add this-buffer))
+
+  (add-hook 'window-size-change-functions
+              explain-pause-top--buffer-window-size-changed)
+
+  (add-hook 'window-configuration-change-hook
+            'explain-pause-top--buffer-window-config-changed nil t)
+
+  (add-hook 'kill-buffer-hook 'explain-pause-top--buffer-killed nil t)
+
+  (explain-pause-top-auto-refresh nil explain-pause-top-auto-refresh-interval))
+
+(defun explain-pause-top--buffer-killed ()
+  "Clean timers and hooks when the buffer is destroyed."
+  (explain-pause-top-auto-refresh)
+  (remove-hook 'window-size-change-functions
+               explain-pause-top--buffer-window-size-changed)
+  (explain-pause-top--pipe-commands 'remove (current-buffer)))
+
+(defun explain-pause-top--buffer-revert (_ignoreauto _noconfirm)
+  (explain-pause-top--buffer-refresh))
+
+(defun explain-pause-top--buffer-resize (width)
+  "resize the current table in the buffer to the WIDTH given, and then redraw it."
+  (explain-pause-top--table-resize-width explain-pause-top--buffer-table width)
+  (explain-pause-top--buffer-refresh))
+
+(defun explain-pause-top--buffer-reschedule-timer ()
+  "Reschedule the timer for this buffer if needed."
+  (when explain-pause-top--buffer-refresh-interval
+    ;; do not repeat any missed timers
+    (let ((timer-max-repeats 0))
+      (setq-local explain-pause-top--buffer-refresh-timer
+                  (run-with-timer explain-pause-top--buffer-refresh-interval
+                                  explain-pause-top--buffer-refresh-interval
+                                  #'explain-pause-top--buffer-refresh-with-buffer
+                                  (current-buffer))))))
+
+(defun explain-pause-top--buffer-refresh-with-buffer (buffer)
+  "Refresh the target BUFFER"
+  (with-current-buffer buffer
+    (explain-pause-top--buffer-refresh)))
+
+(defun explain-pause-top--buffer-refresh ()
+  "Refresh the current buffer - redraw the data at the current target-width"
+  (let ((inhibit-read-only t))
+    (save-excursion
+      (explain-pause-top--table-refresh explain-pause-top--buffer-table))))
+
+(defun explain-pause-top--buffer-window-config-changed ()
+  "Buffer-local hook run when window config changed for a window showing
+this buffer. Update the width if it is wider then the current width."
+  (let ((this-width (window-max-chars-per-line))
+        (current-width (explain-pause-top--table-width
+                        explain-pause-top--buffer-table)))
+    (when (> this-width current-width)
+      (explain-pause-top--buffer-resize this-width))))
+
+(defun explain-pause-top--buffer-update-width-from-windows
+    (buffer updated-frame windows)
+  "Update the width of the target BUFFER with the widest width from WINDOWS,
+filtering WINDOWS with the UPDATED-FRAME. If no more windows exist, set width
+to 0. Does not change buffer if width does not change."
+  (let ((table (buffer-local-value 'explain-pause-top--buffer-table buffer)))
+    (when windows
+      ;; if there are no windows, don't bother changing the size. the buffer
+      ;; still exists, just not been drawn. when it is shown again, sizes
+      ;; will be recalculated.
+      (let ((new-width
+             (seq-reduce
+              (lambda (accum window)
+                (if (eq (window-frame window)
+                        updated-frame)
+                    (max accum
+                         (window-max-chars-per-line window))
+                  accum))
+              windows 0))
+            (existing-width
+             (explain-pause-top--table-width table)))
+        ;; we can't just take the max, because the old largest window might have
+        ;; been closed:
+        (unless (eq new-width existing-width)
+          (with-current-buffer buffer
+            (explain-pause-top--buffer-resize new-width)))))))
+
+(defun explain-pause-top--get-default-buffer ()
+  "Get or recreate the buffer for displaying explain-pause-top"
+  (let ((buffer (get-buffer "*explain-pause-top*")))
+    (unless buffer
+      (setq buffer (generate-new-buffer "*explain-pause-top*"))
+      (with-current-buffer buffer
+        (explain-pause-top-mode)))
+    buffer))
+
+(let ((piped-command-buffers nil)
+      (command-statistics (make-hash-table
+                            :test 'equal)))
+
+  (defun explain-pause-top--pipe-commands (action buffer)
+    "Add or remove (ACTION) the buffer from the list of `explain-pause-top' major
+mode buffers. If there are none, the hook is removed. If there is at least one,
+the hook is added."
+    (cond
+     ((eq action 'add)
+      (add-to-list 'piped-command-buffers buffer))
+     ((eq action 'remove)
+      (setq piped-command-buffers (delq buffer piped-command-buffers))))
+
+    (if (eq (length piped-command-buffers) 0)
+        (remove-hook 'explain-pause-measured-command-hook
+                     #'explain-pause-top--consume-commands)
+      (add-hook 'explain-pause-measured-command-hook
+                #'explain-pause-top--consume-commands)))
+
+  (defun explain-pause-top--consume-commands (ms read-ms command-set)
+    "Consume the event from the stream and add it into the shared store between
+all `explain-pause-top' buffers."
+    (let ((entry (gethash command-set command-statistics nil))
+          (action 'explain-pause-top--table-update))
+      (if entry
+          (let*
+              ((old-count (nth 0 entry))
+               (old-ms (nth 1 entry))
+               (new-count (1+ old-count))
+               (new-ms (+ ms old-ms))
+               (avg (/ (float new-ms) (float new-count))))
+            (setf (nth 0 entry) new-count)
+            (setf (nth 1 entry) new-ms)
+            (setf (nth 2 entry) avg))
+        (setq entry (list 1 ms ms command-set))
+        (puthash command-set entry command-statistics)
+        (setq action 'explain-pause-top--table-insert))
+
+      (dolist (buffer piped-command-buffers)
+        (let ((table (buffer-local-value 'explain-pause-top--buffer-table buffer)))
+          (funcall action table entry))))))
+
+(defun explain-pause-top-auto-refresh (&optional buffer interval)
+  "Turn on or off auto-refresh for the BUFFER, or the current
+buffer if nil. If INTERVAL is nil then auto-refresh is disabled,
+else the INTERVAL is seconds between refreshes."
+  ;; TODO make this interactive better
+  (interactive "bBuffer:\nnInterval: ")
+
+  (unless buffer
+    (setq buffer (current-buffer)))
+
+  (with-current-buffer buffer
+    (when explain-pause-top--buffer-refresh-timer
+      (cancel-timer explain-pause-top--buffer-refresh-timer)
+      (setq-local explain-pause-top--buffer-refresh-timer nil))
+
+    (setq-local mode-name
+                (if interval
+                    (format "Explain Pause Top (every %ss)" interval)
+                  "Explain Pause Top (Paused)"))
+
+    (force-mode-line-update)
+
+    (when interval
+      (setq-local explain-pause-top--buffer-refresh-interval interval)
+      (explain-pause-top--buffer-reschedule-timer))))
+
 ;; command loop hooks
 (defun explain--excluded-command-p (command-set)
   "Should the COMMAND-SET be excluded from analysis?"
@@ -393,8 +1167,9 @@ changed.)"
     "Finish running a measurement loop."
     (let* ((diff (- (explain--as-ms-exact (time-subtract now-snap before-command-snap))
                     read-for-wait))
+           (excluded (explain--excluded-command-p command-set))
            (too-long (and (> diff explain-pause-blocking-too-long-ms)
-                          (not (explain--excluded-command-p command-set))))
+                          (not excluded)))
            (was-profiled profiling-command))
 
       (when was-profiled
@@ -402,6 +1177,10 @@ changed.)"
           ;; only save the profile if it was worth it
           (when too-long
             (explain--store-profile now-snap diff command-set profile))))
+
+      (unless excluded
+        (run-hook-with-args 'explain-pause-measured-command-hook
+                            diff read-for-wait command-set))
 
       (when (or too-long
                 explain-pause-log-all-input-loop)
@@ -508,6 +1287,9 @@ diff is less then the threshold."
                   (explain--store-profile now-snap diff command-set profile))))
 
             (setq executing-command original-execution-command)
+
+            (run-hook-with-args 'explain-pause-measured-command-hook
+                                diff 0 command-set)
 
             (when (or too-long
                       (symbol-value diff-override))
@@ -632,6 +1414,18 @@ filters and sentinels."
     (dolist (hook hooks)
       (remove-hook (car hook) (cdr hook)))))))
 
+;;;###autoload
+(defun explain-pause-top ()
+  "Show a top-like report of commands recently ran and their runtime. Returns
+the buffer."
+  (interactive)
+
+  (let ((buffer (explain-pause-top--get-default-buffer)))
+      ;; this will call resize and that will refresh as width is 0
+      (display-buffer buffer)
+      buffer))
+
+(provide 'explain-pause-top)
 (provide 'explain-pause-mode)
 
 ;;; explain-pause-mode.el ends here


### PR DESCRIPTION
Implements a top-like buffer that resizes according to the largest window viewing it, with a fill left justify column for the command and right justified, shrink (fit largest child) columns for the
rest.
<img width="564" alt="Screen Shot 2020-05-25 at 7 47 05 PM" src="https://user-images.githubusercontent.com/1095956/82857593-4cf41800-9ec6-11ea-9fa3-ef5f9e885bbf.png">

Add a hook that is executed on every command measurement, so that command data can be piped to top.

Lots left to do, but this is a good initial pass. It's pretty interesting to see what runs while you type, actually, so I intend to merge this to get it into master.  There's still a bunch of necessary things like keymaps, faces, documentation and README updates, and restructuring how the log gets data (to use the same hook), and then retiring `explain-pause-profiles` to use this UI instead. Also, various performance things. 

This PR is big enough ;)
