### PR TITLE
Improved top

### DIFF
--- a/tests/test-table.el
+++ b/tests/test-table.el
@@ -1,0 +1,35 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Test table code.
+
+(describe
+ "explain-pause-top--table-generate-offsets"
+ (it "calculates offsets as a vector with fill-width base"
+     (expect
+      (explain-pause-top--table-generate-offsets 23 '(10 5 7 19))
+      :to-equal
+      [0 23 34 40 48])))
+

--- a/tests/test-top.el
+++ b/tests/test-top.el
@@ -26,17 +26,25 @@
 ;;; Test top related code
 
 (describe
- "explain-pause-top--command-entry-number-sorter"
- (it "generates a set of lambdas for sorting"
+ "explain-pause-top--command-entry-number-sorters"
+ (it "generates a list of sorters"
      (let ((lhs (make-explain-pause-top--command-entry
                  :count 10))
            (rhs (make-explain-pause-top--command-entry
                  :count 5))
-           (sorter (explain-pause-top--command-entry-number-sorter 'count)))
-       (expect (funcall sorter lhs rhs)
+           (sorters (explain-pause-top--command-entry-number-sorters (count))))
+
+       (expect (length sorters) :to-be 1)
+       (expect (listp sorters) :to-be-truthy)
+
+       (expect (functionp (car (car sorters))) :to-be-truthy)
+       (expect (functionp (cdr (car sorters))) :to-be-truthy)
+
+       (expect (funcall (car (car sorters)) lhs rhs)
                :to-be
                nil)
-       (expect (funcall sorter rhs lhs)
+
+       (expect (funcall (cdr (car sorters)) lhs rhs)
                :to-be
                t))))
 
@@ -65,26 +73,25 @@
          :command-set '(a)))
        (entry-d
         (make-explain-pause-top--command-entry
-         :command-set '(d)))
-       (sorter
-        (explain-pause-top---command-entry-command-set-sorter nil)))
+         :command-set '(d))))
+
    (it "sorts when sets same size"
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-c
          entry-a)
         :to-be
         t)
 
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-c
          entry-d)
          :to-be
          nil)
 
         (expect
-         (funcall sorter
+         (explain-pause-top---command-entry-command-set-sorter
           entry-c
           entry-c)
           :to-be
@@ -92,7 +99,7 @@
 
    (it "sorts when lhs longer"
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-ca
          entry-a)
         :to-be
@@ -100,7 +107,7 @@
 
    (it "sorts when rhs longer"
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-c
          entry-da)
         :to-be
@@ -108,21 +115,21 @@
 
    (it "sorts after some equal"
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-cab
          entry-cad)
         :to-be
         nil)
 
        (expect
-        (funcall sorter
+        (explain-pause-top---command-entry-command-set-sorter
          entry-cab
          entry-caa)
         :to-be
         t)
 
      (expect
-      (funcall sorter
+      (explain-pause-top---command-entry-command-set-sorter
        entry-cab
        entry-ca)
       :to-be

--- a/tests/test-top.el
+++ b/tests/test-top.el
@@ -1,0 +1,129 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Test top related code
+
+(describe
+ "explain-pause-top--command-entry-number-sorter"
+ (it "generates a set of lambdas for sorting"
+     (let ((lhs (make-explain-pause-top--command-entry
+                 :count 10))
+           (rhs (make-explain-pause-top--command-entry
+                 :count 5))
+           (sorter (explain-pause-top--command-entry-number-sorter 'count)))
+       (expect (funcall sorter lhs rhs)
+               :to-be
+               nil)
+       (expect (funcall sorter rhs lhs)
+               :to-be
+               t))))
+
+(describe
+ "explain-pause-top---command-entry-command-set-sorter"
+ (let ((entry-c
+        (make-explain-pause-top--command-entry
+         :command-set '(c)))
+       (entry-ca
+        (make-explain-pause-top--command-entry
+         :command-set '(c a)))
+       (entry-caa
+        (make-explain-pause-top--command-entry
+         :command-set '(c a a)))
+       (entry-cab
+        (make-explain-pause-top--command-entry
+         :command-set '(c a b)))
+       (entry-cad
+        (make-explain-pause-top--command-entry
+         :command-set '(c a d)))
+       (entry-da
+        (make-explain-pause-top--command-entry
+         :command-set '(d a)))
+       (entry-a
+        (make-explain-pause-top--command-entry
+         :command-set '(a)))
+       (entry-d
+        (make-explain-pause-top--command-entry
+         :command-set '(d)))
+       (sorter
+        (explain-pause-top---command-entry-command-set-sorter nil)))
+   (it "sorts when sets same size"
+       (expect
+        (funcall sorter
+         entry-c
+         entry-a)
+        :to-be
+        t)
+
+       (expect
+        (funcall sorter
+         entry-c
+         entry-d)
+         :to-be
+         nil)
+
+        (expect
+         (funcall sorter
+          entry-c
+          entry-c)
+          :to-be
+          nil))
+
+   (it "sorts when lhs longer"
+       (expect
+        (funcall sorter
+         entry-ca
+         entry-a)
+        :to-be
+        t))
+
+   (it "sorts when rhs longer"
+       (expect
+        (funcall sorter
+         entry-c
+         entry-da)
+        :to-be
+        nil))
+
+   (it "sorts after some equal"
+       (expect
+        (funcall sorter
+         entry-cab
+         entry-cad)
+        :to-be
+        nil)
+
+       (expect
+        (funcall sorter
+         entry-cab
+         entry-caa)
+        :to-be
+        t)
+
+     (expect
+      (funcall sorter
+       entry-cab
+       entry-ca)
+      :to-be
+      t))))

--- a/tests/test-top.el
+++ b/tests/test-top.el
@@ -134,3 +134,42 @@
        entry-ca)
       :to-be
       t))))
+
+(describe
+ "explain-pause-top--split-at-space"
+
+ (it "does nothing when it fits"
+     (expect
+      (explain-pause-top--split-at-space "aaa" '(5))
+      :to-equal
+      '("aaa")))
+
+ (it "splits at the max-boundary when there is no spaces or commas"
+     (expect
+      (explain-pause-top--split-at-space "aaaaa" '(3))
+      :to-equal
+      '("aa\\" "aaa")))
+
+ (it "splits at least twice when there is no spaces or commas, and with no blank lines at the end"
+     (expect
+      (explain-pause-top--split-at-space "aaaabbbbccccc" '(4))
+      :to-equal
+      '("aaa\\" "abb\\" "bbc\\" "cccc")))
+
+ (it "splits at a space"
+     (expect
+      (explain-pause-top--split-at-space "aa bcd" '(3))
+      :to-equal
+      '("aa" "bcd")))
+
+ (it "splits two lines at space and max and space"
+     (expect
+      (explain-pause-top--split-at-space "aa bcdef gh" '(3))
+      :to-equal
+      '("aa" "bc\\" "def" "gh")))
+
+ (it "splits multiple max-lengths"
+     (expect
+      (explain-pause-top--split-at-space "abcdef ghi" '(2 10))
+      :to-equal
+      '("a\\" "bcdef ghi"))))


### PR DESCRIPTION
1. Keymap - sort, clear, auto-refresh
2. Sort works under point, and interactively. Sorting twice under the same column flips the order. Sort works on the command column, too.
3. Clear clears the accumulated statistics.
4. Auto-refresh now requests the right buffers and values if called interactively.
5. Change various lists into vectors for performance.
6. Create a new struct to capture command-entry instead of nth'ing into a list.
7. Actually make it not typecheck in byte-compiled mode.
8. Add new column to top, "slow calls" which are the number of calls ... slow.
9. Fix bugs if user requests the top-major-mode on a new buffer, instead of using `explain-pause-top` directly.
10. Add the beginnings of more unit tests.

- [x] Faces
- [x] Break commands on commas and spaces, instead of randomly in the middle of a word, if possible

Fixes #24 