### PR TITLE
Fix display crash OOB when items exist on first render of `top`

### DIFF
--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -578,10 +578,9 @@ the width cannot be 0."
   (let* ((display-order-ptr (cdr (explain-pause-top--table-entries table)))
          (display-entries-prev (explain-pause-top--table-display-entries table))
          (display-entries-ptr (cdr display-entries-prev))
-         (display-column-widths (explain-pause-top--table-column-widths table))
-         (column-count (length display-column-widths))
          (requested-widths (copy-sequence
                             (explain-pause-top--table-header-widths table)))
+         (column-count (length requested-widths))
          (layout-changed nil)
          (current-diffs (make-vector column-count nil)))
 
@@ -629,7 +628,7 @@ the width cannot be 0."
     ;; changed. If so, we'll force `draw` to draw full lines:
     ;; (TODO could we only paint things "after" the first change?)
     (when (or
-           (cl-mismatch display-column-widths
+           (cl-mismatch (explain-pause-top--table-column-widths table)
                         requested-widths
                         :start1 1
                         :start2 1


### PR DESCRIPTION
The number of columns used to be calculated from the number of `display-column-widths`. On first render, this is nil, because `needs-resize` is `t`, and nothing has yet been calculated. This however still worked so long the buffer rendered once before adding new entires. If entries existed on first render, the column count would be 0.

Fix by calculating column count off of `header-widths`, which is always set correctly.

Fixes #40 