### PR TITLE
Wrap post and pre command hooks with frames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `explain-pause-top`.
 * Add two user notification levels, `developer` and `normal`. The default is `normal`. In `normal`, `explain-pause-mode` notifies the user occasionally about slow commands. In `developer`, it always notifies the user immediately.
 * Add custom faces for `explain-pause-top`.
+* Measure code run in `post-command-hook`, `pre-command-hooks`, `post-gc-hook`, and a few other rarer hooks.
 
 #### New custom variables
 * `explain-pause-top-auto-refresh-interval`
@@ -24,3 +25,4 @@
 * Fix `magit` commit locally sometimes breaking when `explain-pause` attempts to profile while already profiling ([#26](https://github.com/lastquestion/explain-pause-mode/issues/))
 * Fix `emacsclient -nw` not working ([#50](https://github.com/lastquestion/explain-pause-mode/issues/50))
 * Fix `kill-buffer` not being recorded when quitting out of command ([#58](https://github.com/lastquestion/explain-pause-mode/issues/58))
+* Fix `flyspell` not working because of `post-command-hook` ([#54](https://github.com/lastquestion/explain-pause-mode/issues/54))

--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -3108,7 +3108,8 @@ callback."
         (set-process-sentinel process original-sentinel)))))
 
 (defconst explain-pause--native-called-hooks
-  '(post-command-hook pre-command-hook))
+  '(post-command-hook pre-command-hook delayed-warnings-hook
+                      echo-area-clear-hook post-gc-hook))
 
 (defsubst explain-pause--generate-hook-wrapper (hook-func hook-list)
   "Generate a lambda wrapper for advice to wrap the function HOOK-FUNC so it

--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -226,7 +226,7 @@ may generate strings with format specifiers in them."
             (seq-filter #'symbolp (aref cmd 2))))
    ((not (listp cmd))
     ;; something weird. This should not happen.
-    "Unknown (please file a bug)")
+    (format "Unknown (please file a bug) %s" cmd))
    ;; closure. hypothetically, this is defined as a implementation detail,
    ;; but we'll read it anyway...
    ((eq (car cmd) 'closure)
@@ -235,7 +235,7 @@ may generate strings with format specifiers in them."
    ((eq (car cmd) 'lambda)
     (format "<lambda> (arg-list: %s)" (nth 1 cmd)))
    (t
-    "Unknown (please file a bug)")))
+    (format "Unknown (please file a bug) %s" cmd))))
 
 ;; TODO not used right now...
 (defun explain-pause--command-set-as-string (command-set)
@@ -3107,6 +3107,73 @@ callback."
         (set-process-filter process original-filter)
         (set-process-sentinel process original-sentinel)))))
 
+(defconst explain-pause--native-called-hooks
+  '(post-command-hook pre-command-hook))
+
+(defsubst explain-pause--generate-hook-wrapper (hook-func hook-list)
+  "Generate a lambda wrapper for advice to wrap the function HOOK-FUNC so it
+generates a frame as HOOK-LIST when called. We grab the original symbol
+of HOOK-FUNC, so we can refer to the symbol if possible."
+  ;; TODO perhaps dry with explain-pause--wrap-callback
+  (lambda (orig-func &rest args)
+    (if (not explain-pause-mode)
+        (apply orig-func args)
+
+      (explain-pause--pause-call-unpause
+       (format "wrap hook %s for %s" hook-func hook-list)
+       ;; it would be nice to avoid this let but in hooks people make them
+       ;; re-entrant and just call them randomly. be defensive.
+       (let ((parent
+              (explain-pause--command-record-from-parent
+               current-record
+               ;; the parent is root because we are being called from
+               ;; native code outside the command loop. TODO it's possible
+               ;; we can figure out more accurately?
+               explain-pause-root-command-loop
+               hook-list)))
+         (explain-pause--command-record-from-parent
+          parent
+          parent
+          hook-func))
+       (apply orig-func args)))))
+
+(defsubst explain-pause--advice-add-hook (hook-func hook-list)
+  "Add a hook-wrapper advice for HOOK-FUNC for type HOOK-LIST, naming the
+lambda advice so we can reference it later."
+  (advice-add hook-func :around
+              (explain-pause--generate-hook-wrapper hook-func hook-list)
+              '((name . (format "explain-pause-wrap-hook-%s" hook-list)))))
+
+(defun explain-pause--wrap-add-hook (args)
+  "Advise add-hook to advise the hook itself to add a frame when called from
+native code outside command loop."
+  (let* ((hook-list (nth 0 args))
+         (hook-func (nth 1 args)))
+    (when (and (seq-contains explain-pause--native-called-hooks hook-list)
+               (functionp hook-func))
+      (explain-pause--advice-add-hook hook-func hook-list)))
+  args)
+
+(defun explain-pause--wrap-existing-hooks-in-list (hook-kind hook-list)
+  "Wrap existing hooks in HOOK-LIST with WRAP-FUNC."
+  (dolist (hook hook-list)
+    (when (functionp hook)
+      (explain-pause--advice-add-hook hook hook-kind))))
+
+(defun explain-pause--wrap-existing-hooks ()
+  "Wrap existing hooks in hook lists that are called from native code outside
+command loop, for both the default value and all buffer local values."
+  (dolist (hook-list explain-pause--native-called-hooks)
+    ;; the default value
+    (explain-pause--wrap-existing-hooks-in-list hook-list (default-value hook-list))
+    ;; for each buffer
+    (cl-loop
+     for buffer being the buffers
+     do
+     (explain-pause--wrap-existing-hooks-in-list
+      hook-list
+      (buffer-local-value hook-list buffer)))))
+
 (eval-and-compile
   (let ((callback-family
          '(
@@ -3164,6 +3231,8 @@ callback."
                   #'explain-pause--wrap-call-interactively)
       (advice-add 'funcall-interactively :before
                   #'explain-pause--before-funcall-interactively)
+      (advice-add 'add-hook :filter-args
+                  #'explain-pause--wrap-add-hook)
 
       ;; OK, we're prepared to advise native functions and timers:
       (dolist (native-func native)
@@ -3200,6 +3269,7 @@ callback."
 
       (explain-pause--wrap-existing-processes)
       (explain-pause--wrap-existing-timers)
+      (explain-pause--wrap-existing-hooks)
 
       (when explain-pause-log--send-process
         (explain-pause-log--send-dgram
@@ -3272,6 +3342,9 @@ github.com/lastquestion/explain-pause-mode")
       (dolist (native-func native)
         (advice-remove native-func
                        #'explain-pause--wrap-native))
+
+      (advice-remove 'add-hook
+                     #'explain-pause--wrap-add-hook)
 
       (advice-remove 'call-interactively
                      #'explain-pause--wrap-call-interactively)

--- a/tests/cases/driver.el
+++ b/tests/cases/driver.el
@@ -58,7 +58,8 @@ exit-command in the session."
 
       (cond
        ((and command
-            (string-match "exit-test" command))
+             (string-match "exit-test" command)
+             (not (equal "exit-test-quit-emacs-check" command)))
         (message "... emacs terminated: %s" command)
         (setf (nth 5 (process-get process :session)) command))
        ((equal "enabled" (nth 0 event))

--- a/tests/cases/driver.el
+++ b/tests/cases/driver.el
@@ -57,10 +57,8 @@ exit-command in the session."
       (push event event-stream)
 
       (cond
-       ((or
-             (equal "exit-test-quit-emacs" command)
-             (equal "exit-test-debugger-invoked" command)
-             (equal "exit-test-unclean" command))
+       ((and command
+            (string-match "exit-test" command))
         (message "... emacs terminated: %s" command)
         (setf (nth 5 (process-get process :session)) command))
        ((equal "enabled" (nth 0 event))
@@ -429,6 +427,11 @@ it is assumed `test-setup' has trapped."
     (signal-process (nth 1 session) 'sigusr1)))
 
 ;; inside tested code functions
+(defun quit-with-record (record)
+  (send-exit-record record)
+  (unless (getenv "NODIE")
+    (kill-emacs 1)))
+
 (defun check-buffers ()
   "Find any buffer with backtrace or explain-pause-mode-report-bug or
 if messages buffer has error message."
@@ -439,9 +442,16 @@ if messages buffer has error message."
      (when (or (string-match-p "backtrace" name)
                (string-match-p "explain-pause-mode-report-bug" name)
                (string-match-p "Warnings" name))
-       (send-exit-record "exit-test-debugger-invoked")
-       (unless (getenv "NODIE")
-         (kill-emacs 1))))))
+       (quit-with-record "exit-test-debugger-invoked"))))
+
+  (with-current-buffer (messages-buffer)
+    (goto-char 0)
+    (unless (re-search-forward "Debug on Error enabled globally" nil t)
+      (quit-with-record "exit-test-debug-on-error-off"))
+
+    (when (re-search-forward "error" nil t)
+      (quit-with-record "exit-test-message-error"))))
+
 
 (defun send-value (name val)
   "Send the name/value pair to the event log. Run only inside tested code."
@@ -455,23 +465,27 @@ if messages buffer has error message."
   (explain-pause-log--send-dgram
    (format "(\"enter\" \"%s\")\n" why)))
 
-(defun exit-test-quit-emacs ()
+(defun exit-test-quit-emacs-check ()
   (interactive)
   "Call after-test, and then close and quit emacs. Run by SIGUSR1."
   ;; assumed defined in test file
   (check-buffers)
   (after-test)
+  (call-interactively 'exit-test-quit-emacs))
+
+(defun exit-test-quit-emacs ()
+  (interactive)
   (send-exit-record "exit-test-unclean")
-  (explain-pause-log-off)
   (unless (getenv "NODIE")
+    (explain-pause-log-off)
     (kill-emacs)))
 
 (defun exit-test-debugger-invoked ()
   (interactive)
   (check-buffers)
   (send-exit-record "exit-test-unclean")
-  (explain-pause-log-off)
   (unless (getenv "NODIE")
+    (explain-pause-log-off)
     (kill-emacs)))
 
 (defun setup-test-boot ()
@@ -488,6 +502,6 @@ into the event stream and then quit."
               (call-interactively 'exit-test-debugger-invoked)))
   (toggle-debug-on-error)
 
-  (define-key special-event-map [sigusr1] 'exit-test-quit-emacs)
+  (define-key special-event-map [sigusr1] 'exit-test-quit-emacs-check)
 
   (explain-pause-log-to-socket (getenv "SOCKET")))

--- a/tests/cases/minibuffer-menu-timer.el
+++ b/tests/cases/minibuffer-menu-timer.el
@@ -28,7 +28,7 @@
 ;;; against each other.
 
 (defun before-test ()
-  t)
+  (setq explain-pause-profile-enabled nil))
 
 (defun timer-func ()
   (sleep-for 0.1))
@@ -51,6 +51,7 @@
     (send-special-key session 'quit)
     (sleep-for 0.5)
     (send-special-key session 'quit)
+    (sleep-for 0.5)
     (call-after-test session)
     (wait-until-dead session)))
 

--- a/tests/cases/test-hook-add-remove.el
+++ b/tests/cases/test-hook-add-remove.el
@@ -1,0 +1,84 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; test hook add/remove
+
+;; TODO this needs to move to a new folder for tests that need
+;; explain-pause-mode loaded but not a full subemacs.
+
+(load-file "./explain-pause-mode.el")
+
+(defun test-hook ()
+  (setq test-hook-run t))
+
+(defun it-adds-removes-symbols ()
+  (let ((passed 0))
+    (add-hook 'post-command-hook 'test-hook)
+
+    (setq test-hook-run nil)
+    (run-hooks 'post-command-hook)
+    (message-assert
+     test-hook-run
+     "Test hook ran after adding")
+
+    (remove-hook 'post-command-hook 'test-hook)
+    (setq test-hook-run nil)
+    (run-hooks 'post-command-hook)
+    (message-assert
+     (not test-hook-run)
+     "Test hook did not run after removing")
+
+    passed))
+
+(defun it-adds-removes-lambda ()
+  (let* ((passed 0)
+         (ran nil)
+         (hook (lambda ()
+                 (setq ran t))))
+
+    (add-hook 'post-command-hook hook)
+    (run-hooks 'post-command-hook)
+    (message-assert
+     ran
+     "Lambda hook ran after adding")
+
+    (remove-hook 'post-command-hook hook)
+    (setq ran nil)
+    (run-hooks 'post-command-hook)
+    (message-assert
+     (not ran)
+     "Lambda hook did not run after removing")
+
+    passed))
+
+;; driver code
+(defun run-test ()
+  (explain-pause-mode--install-hooks)
+
+  (let ((passed
+         (and (it-adds-removes-symbols)
+              (it-adds-removes-lambda))))
+
+    (kill-emacs passed)))

--- a/tests/cases/test-process-measurement.el
+++ b/tests/cases/test-process-measurement.el
@@ -84,7 +84,7 @@
 
 ;; driver code
 (defun run-test ()
-  (explain-pause-mode)
+  (explain-pause-mode--install-hooks)
   (let ((passed
          (and (it-hides-process-filters)
               (it-works-when-nil-passed))))

--- a/tests/unit/test-command-logging.el
+++ b/tests/unit/test-command-logging.el
@@ -78,13 +78,13 @@
      (expect (explain-pause--command-as-string
               '(bar))
               :to-equal
-              "Unknown (please file a bug)"))
+              "Unknown (please file a bug) (bar)"))
 
  (it "prints unknown for values"
      (expect (explain-pause--command-as-string
               10)
               :to-equal
-              "Unknown (please file a bug)"))
+              "Unknown (please file a bug) 10"))
 
  (it "works for subrp"
      (expect (explain-pause--command-as-string

--- a/tests/unit/test-measurement.el
+++ b/tests/unit/test-measurement.el
@@ -165,3 +165,48 @@
   (expect (explain-pause--interactive-form-needs-frame-p "Mprompt: ")
           :to-be
           t)))
+
+(defun test-function () t)
+(defun byte-compile-function () t)
+
+(describe
+ "explain-pause--advice-add-hook"
+
+ (before-all
+  (byte-compile 'byte-compile-function))
+
+ (it
+  "advises a symbol function and returns it"
+  (expect
+   (explain-pause--advice-add-hook 'test-function 'test-list)
+   :to-be
+   'test-function)
+
+  (expect
+   (advice--p (symbol-function 'test-function))
+   :to-be
+   t))
+
+ (it
+  "advises a bytecompiled function"
+  (expect
+   (explain-pause--advice-add-hook 'byte-compile-function 'test-list)
+   :to-be
+   'byte-compile-function)
+
+  (expect
+   (advice--p (symbol-function 'byte-compile-function))
+   :to-be
+   t))
+
+ (it
+  "advises a lambda"
+  (setq test-lambda (lambda () t))
+  (setq result-lambda (explain-pause--advice-add-hook test-lambda 'test-list))
+  (expect result-lambda
+          :not :to-equal
+          test-lambda)
+  (setq result2-lambda (explain-pause--advice-add-hook result-lambda 'test-list))
+  (expect result2-lambda
+          :to-equal
+          result-lambda)))


### PR DESCRIPTION
Post and pre command hooks are run from `keyboard.c` outside the command loop, so they don't have any command frame parents.

Advise `add-hook` so that we advise hooks added to `pre` and `post` command hooks so that the hooks themselves add frames before running the original hook.

When enabling, go through all existing hooks and make sure they are also advised.

Fixes #54.

- [x] Needs tests
- [x] Needs update of `CHANGELOG`