### PR TITLE
Recognize when a interactive form is abort-quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 * Improve how `explain-pause-top` shows lambdas and closures ([#34](https://github.com/lastquestion/explain-pause-mode/issues/))
 * Fix `magit` commit locally sometimes breaking when `explain-pause` attempts to profile while already profiling ([#26](https://github.com/lastquestion/explain-pause-mode/issues/))
 * Fix `emacsclient -nw` not working ([#50](https://github.com/lastquestion/explain-pause-mode/issues/50))
+* Fix `kill-buffer` not being recorded when quitting out of command ([#58](https://github.com/lastquestion/explain-pause-mode/issues/58))

--- a/tests/cases/abort-quit-interactive.el
+++ b/tests/cases/abort-quit-interactive.el
@@ -1,0 +1,61 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; test case for #58
+;;; Aborting out of a command before it is run during the interactive
+;;; phase should work.
+(defun before-test ()
+  t)
+
+(defun after-test ()
+  t)
+
+(defun test-func (buff)
+  (interactive "bBuffer:")
+  t)
+
+;; driver code
+(defun run-test ()
+  (let ((session (start-test)))
+    (wait-until-ready session)
+    (m-x-run session "test-func")
+    (send-special-key session 'quit)
+    (sleep-for 1)
+    (call-after-test session)
+    (wait-until-dead session)))
+
+(defun finish-test (session)
+  (let* ((stream (reverse event-stream))
+         (passed 0))
+
+    (message-assert
+     (found-span-p (span-func stream "call-interactively-interactive"))
+     "Call interactively interactive exists")
+
+    (message-assert
+     (not (found-span-p (span-func stream "test")))
+     "Test frames do not exist as it was never called")
+
+    (kill-emacs passed)))

--- a/tests/cases/driver.el
+++ b/tests/cases/driver.el
@@ -79,6 +79,11 @@ exit-command in the session."
          (end (find-ptr-between (cons (cdr start) (cdr span)) pred-end)))
     (cons start end)))
 
+(defun found-span-p (span)
+  "Is the span not empty?"
+  (and (car span)
+       (cdr span)))
+
 (defun span (head pred-start pred-end)
   "Find the span with the first passing PRED-START and first
 passing PRED-END after that found PRED-START in ( start . end ),


### PR DESCRIPTION
When a interactive form is abort-quit, `funcall-interactively` is never called, which means the command frame is never pushed onto the stack. Recognize this and handle it, instead of dying.

Fixes #58.