### PR TITLE
make-process allows stderr as string, and creates a pipe process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 * Fix `emacsclient -nw` not working ([#50](https://github.com/lastquestion/explain-pause-mode/issues/50))
 * Fix `kill-buffer` not being recorded when quitting out of command ([#58](https://github.com/lastquestion/explain-pause-mode/issues/58))
 * Fix `flyspell` not working because of `post-command-hook` ([#54](https://github.com/lastquestion/explain-pause-mode/issues/54))
+* Fix `notmuch` not working because `make-process` can create `stderr` processes ([#64](https://github.com/lastquestion/explain-pause-mode/issues/64))

--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -2869,6 +2869,8 @@ any."
   (let* ((current-record explain-pause--current-command-record)
 
          (process-name (plist-get args :name))
+         (stderr-arg (plist-get args :stderr))
+
          ;; this represents the process itself
          (process-frame
           (explain-pause--command-record-from-parent
@@ -2916,7 +2918,31 @@ any."
         (when original-filter
           (process-put process 'explain-pause-original-filter original-filter))
         (when original-sentinel
-          (process-put process 'explain-pause-original-sentinel original-sentinel)))
+          (process-put process 'explain-pause-original-sentinel original-sentinel))
+
+        ;; if there was a stderr argument, and the stderr argument was not a
+        ;; process, then the stderr process was created in make-process
+        ;; directly calling Fmake_pipe_process in C code. Pull that newly
+        ;; made process out, and retroactively give it a process-frame.
+        ;; note that the native call does not give it filters or anything
+        ;; fancy we need to account for. (process.c)
+        ;; stderr is only supported for make-process, not make-network-process
+        ;; or make-pipe-process, but this value will be nil in those calls,
+        ;; so we can handle all cases here.
+        (when (and stderr-arg
+                   (not (processp stderr-arg)))
+          ;; exactly mirror the C code here
+          (let* ((stderr-buffer (get-buffer-create stderr-arg))
+                 (stderr-proc (get-buffer-process stderr-buffer))
+                 (stderr-process-frame
+                  (explain-pause--command-record-from-parent
+                   current-record
+                   current-record
+                   (format "%s - %s" process-name stderr-arg))))
+
+            (process-put stderr-proc
+                         'explain-pause-process-frame
+                         stderr-process-frame))))
 
       process)))
 

--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -2940,9 +2940,14 @@ any."
                    current-record
                    (format "%s - %s" process-name stderr-arg))))
 
-            (process-put stderr-proc
-                         'explain-pause-process-frame
-                         stderr-process-frame))))
+            ;; this might be nil if the process didn't start, or the buffer
+            ;; didn't exist and was created, etc. let's be defensive. if the
+            ;; process is nil anyway no one can find the process any other way,
+            ;; so user code can't try to set process filters on it.
+            (when stderr-proc
+              (process-put stderr-proc
+                           'explain-pause-process-frame
+                           stderr-process-frame)))))
 
       process)))
 

--- a/tests/cases/process-stderr-buffer.el
+++ b/tests/cases/process-stderr-buffer.el
@@ -1,0 +1,59 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; test case for #64, nil dereference because stderr arg to
+;;; make-process can be a string or buffer, and the process is created
+;;; in native code
+
+(defun my-sentinel (proc event) t)
+
+(defun before-test ()
+  (setq proc (make-process
+              :name "test"
+              :buffer "test"
+              :command '("cat")
+              :stderr "my-awesome-buffer"))
+
+  (set-process-sentinel
+   (get-buffer-process (get-buffer "my-awesome-buffer"))
+   'my-sentinel))
+
+(defun after-test ()
+  (delete-process proc))
+
+;; driver code
+(defun run-test ()
+  (let ((session (start-test)))
+    (wait-until-ready session)
+    (sleep-for 1)
+    (call-after-test session)
+    (wait-until-dead session)))
+
+(defun finish-test (session)
+  (let ((passed 0))
+    (message-assert
+     (equal (nth 5 session) "exit-test-quit-emacs")
+     "set-process-sentinel succeeded on stderr process created in C make-process.")
+    (kill-emacs passed)))

--- a/tests/cases/process-stderr-process.el
+++ b/tests/cases/process-stderr-process.el
@@ -1,0 +1,62 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; negative test case for #64, when stderr is a process
+
+(defun my-sentinel (proc event) t)
+(defun a-filter (proc str) t)
+
+(defun before-test ()
+  (setq err-proc
+        (make-pipe-process
+         :name "test-err"
+         :buffer "my-awesome-buffer"
+         :filter 'a-filter))
+
+  (setq proc (make-process
+              :name "test"
+              :buffer "test"
+              :command '("cat")
+              :stderr err-proc))
+
+  (set-process-sentinel err-proc 'my-sentinel))
+
+(defun after-test ()
+  (delete-process proc))
+
+;; driver code
+(defun run-test ()
+  (let ((session (start-test)))
+    (wait-until-ready session)
+    (sleep-for 1)
+    (call-after-test session)
+    (wait-until-dead session)))
+
+(defun finish-test (session)
+  (let ((passed 0))
+    (message-assert
+     (equal (nth 5 session) "exit-test-quit-emacs")
+     "set-process-sentinel succeeded on stderr process created via elisp make-pipe-process.")
+    (kill-emacs passed)))


### PR DESCRIPTION
When this occurs, retroactively attach a process-frame for the pipe process created in C code. Fixes #64