### PR TITLE
New makefile targets, improve report bug, add tests for report bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.elc
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,57 @@
+# override this for different emacs
 EMACS=emacs
+
+# this should point to the emacs that has packages installed
+EMACS_PACKAGES=emacs
+
+# turn off garbage collection while running tests
+EMACS_OPTS=--eval="(setq gc-cons-threshold most-positive-fixnum)"
 
 # the test case that need full emacs driver
 case-driver=tests/cases/driver.el
 cases:=$(filter-out $(case-driver), $(wildcard tests/cases/*.el))
 
+# the unit tests
+unit-tests:=$(filter-out tests/unit/manual-test-command-logging.el, $(wildcard tests/unit/*.el))
+
 # root project directory. use absolute paths so we can use any emacs
 # note this has a trailing /
 ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
+# whitespace matters here!
+find_buttercup_from_packages=$(shell $(EMACS_PACKAGES) $(EMACS_OPTS) --batch -f package-initialize --eval='(princ (file-name-directory (locate-library "buttercup")))')
+# find it, and save it, so we cache it for next time
+find_set_buttercup_from_packages=$(eval BUTTERCUP_DIR:=$(find_buttercup_from_packages))$(BUTTERCUP_DIR)
+get_buttercup=$(if $(BUTTERCUP_DIR),$(BUTTERCUP_DIR),$(info Buttercup not specified; finding buttercup from emacs packages...)$(find_set_buttercup_from_packages))
+
 # all the test cases don't generate output so they need to be PHONY
-.PHONY: test case-tests $(cases)
+.PHONY: test case-tests $(cases) $(unit-tests) print-emacs-version
+
+all: byte-compile tests
 
 byte-compile:
-	$(EMACS) -batch -f batch-byte-compile explain-pause-mode.el
+	$(EMACS) $(EMACS_OPTS) -batch --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile explain-pause-mode.el
 
 print-emacs-version:
-	@echo $(ROOT_DIR)
 	@echo "Emacs version under test: " `$(EMACS) --version | head -n 1`
 
 case-tests: $(cases)
 
 $(cases): %.el: print-emacs-version
-	$(EMACS) -batch -Q -f toggle-debug-on-error -l $(case-driver) -l $@ -f "run-test"
+	$(EMACS) $(EMACS_OPTS) -batch -Q -f toggle-debug-on-error -l $(case-driver) -l $@ -f run-test
 
-unit-tests: print-emacs-version
-	EMACSLOADPATH=$(BUTTERCUP_DIR): $(EMACS) -batch -Q -l explain-pause-mode.el -l buttercup.el -f buttercup-run-discover $(ROOT_DIR)tests/unit
-	$(EMACS) -batch -Q -l explain-pause-mode.el -l tests/unit/manual-test-command-logging.el
+$(unit-tests): %.el: print-emacs-version
+	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l buttercup.el -l $@ -f buttercup-run
+
+tests/unit/manual-test-command-logging.el: print-emacs-version
+	$(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l tests/unit/manual-test-command-logging.el
+
+unit-tests: tests/unit/manual-test-command-logging.el print-emacs-version
+	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l buttercup.el -f buttercup-run-discover $(ROOT_DIR)tests/unit
 
 tests: unit-tests case-tests
+
+up-version:
+	@read -p "New version: " VERSION; \
+	find . -name "*.el" -exec sed -i '' "s/^;; Version: .*$$/;; Version: $$VERSION/g" {} + \
+	sed -i '' "s/^(defconst explain-pause-version .*$$/(defconst explain-pause-version $$VERSION/g" explain-pause-mode.el

--- a/tests/cases/sit-for-inside-timers.el
+++ b/tests/cases/sit-for-inside-timers.el
@@ -70,14 +70,14 @@
 
     (message-assert
      (< (exit-measured-time (cadr non-interactive-timer)) 2)
-     "Timer non-interactive did not subtract sit-for")
+     "Timer non-interactive subtracted sit-for")
 
     (message-assert
      (< (exit-measured-time (cadr interactive-timer-1)) 2)
-     "Timer interactive did not subtract sit-for")
+     "Timer interactive subtracted sit-for")
 
     (message-assert
      (< (exit-measured-time (cadr interactive-timer-2)) 2)
-     "Timer interactive interrupted with keys did not subtract sit-for")
+     "Timer interactive interrupted with keys subtracted sit-for")
 
     (kill-emacs passed)))

--- a/tests/unit/test-report-bug.el
+++ b/tests/unit/test-report-bug.el
@@ -1,0 +1,146 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Test report bug
+(defmacro mock-and-call (&rest body)
+  ;; https://github.com/jorgenschaefer/emacs-buttercup/issues/180
+  `(let ((saved-explain-pause-mode (symbol-function 'explain-pause-mode))
+         (saved-profiler-cpu-stop (symbol-function 'profiler-cpu-stop)))
+     (setq explain-pause-mode-call nil)
+     (setq profiler-cpu-stop-call nil)
+
+     (unwind-protect
+         (progn
+           (setf (symbol-function 'explain-pause-mode)
+                 (lambda (&rest args)
+                   (setq explain-pause-mode-call (cons 'called args))))
+           (setf (symbol-function 'profiler-cpu-stop)
+                 (lambda (&rest args)
+                   (setq profiler-cpu-stop-call (cons 'called args))))
+           ,@body)
+
+       (setf (symbol-function 'explain-pause-mode) saved-explain-pause-mode)
+       (setf (symbol-function 'profiler-cpu-stop) saved-profiler-cpu-stop))))
+
+(describe
+ "explain-pause-report-measuring-bug"
+ :var (the-body
+       the-buffer
+       explain-pause-mode-call
+       profiler-cpu-stop-call)
+
+ (describe
+  "working case"
+  (before-all
+   ;; https://github.com/jorgenschaefer/emacs-buttercup/issues/179
+   (condition-case err
+       (progn
+         (mock-and-call
+          (explain-pause-report-measuring-bug
+           "The place where we bugged"
+           "some-record"
+           (make-explain-pause-command-record
+            :command 'bar
+            :depth 0)
+           "some-string"
+           "a happy string"))
+
+         (setq the-buffer (get-buffer "explain-pause-mode-report-bug"))
+
+         (when the-buffer
+           (with-current-buffer the-buffer
+             (setq the-body (buffer-string)))))
+     (error
+      (message "before-all failed %s" err))))
+
+  (after-all
+   (kill-buffer the-buffer))
+
+  (it
+   "disables the mode and turns off profiling"
+   (expect explain-pause-mode-call :to-equal '(called -1))
+   (expect profiler-cpu-stop-call :to-equal '(called)))
+
+  (it
+   "creates the buffer"
+   (expect the-buffer :not :to-be nil))
+
+  (it
+   "puts the explain-pause-version"
+   (expect
+    (string-match "^explain-pause.*version:\\s-+\\(.*\\)$" the-body)
+    :not :to-be nil)
+
+   (expect
+    (match-string 1 the-body)
+    :to-equal
+    (format "%s" explain-pause-version)))
+
+  (it
+   "puts the emacs version"
+   (expect
+    (string-match "^emacs version:\\s-+\\(.*\\)$" the-body)
+    :not :to-be nil)
+
+   (expect
+    (match-string 1 the-body)
+    :to-equal
+    (format "%s" emacs-version)))
+
+  (it
+   "prints a backtrace"
+   (expect
+    (string-match "Backtrace:" the-body) :not :to-be nil)
+
+   ;; buttercup is in the backtrace
+   (expect
+    (string-match "buttercup" the-body) :not :to-be nil)
+
+   ;; make sure the first line is the bug report function
+   (expect
+    (string-match "Backtrace:\n\\s-+explain-pause-report-measuring-bug" the-body)
+    :not :to-be nil))
+
+  (it
+   "prints the additional args"
+   (expect
+    (string-match
+     "some-record\n(.*)explain-pause-command-record(.*)\nsome-string\na happy string"
+     the-body)
+    :not :to-be nil)))
+
+ (it
+  "works even with no optional args"
+  (ignore-errors
+    (kill-buffer "explain-pause-mode-report-bug"))
+  (mock-and-call
+   (explain-pause-report-measuring-bug
+    "wow"))
+  (expect explain-pause-mode-call
+          :to-equal '(called -1))
+  (expect profiler-cpu-stop-call
+          :to-equal '(called))
+  (expect (get-buffer "explain-pause-mode-report-bug")
+          :not :to-be nil)))


### PR DESCRIPTION
1. New makefile targets:
  * Up-version (in preparation for next version): ups all versions in the licenses for all files
  * BUTTERCUP_DIR is now automatically found if not given from packages
  * stop GC during tests
  * add unit test targets for per file unit testing
  * add all default target
  * make bytecode fail on warn

2. Improve report bug
  * Add versions of explain-pause and emacs
  * Allow any number of additional parameters
  * Clarify error text in various cases
  * Improve backtrace to skip over known code (fixes #55)

3. Add unit tests for report-bug.

4. Also, fix assert text for a test.