### PR TITLE
Catch errors during install during post-command-hook

### DIFF
--- a/tests/cases/driver.el
+++ b/tests/cases/driver.el
@@ -470,8 +470,8 @@ if messages buffer has error message."
   (interactive)
   "Call after-test, and then close and quit emacs. Run by SIGUSR1."
   ;; assumed defined in test file
-  (check-buffers)
   (after-test)
+  (check-buffers)
   (call-interactively 'exit-test-quit-emacs))
 
 (defun exit-test-quit-emacs ()

--- a/tests/cases/wrap-existing.el
+++ b/tests/cases/wrap-existing.el
@@ -124,7 +124,7 @@
          (passed 0))
 
     (message-assert-not
-     (nth 1 (find-ptr event-stream (find-by "value" "message-index")))
+     (get-value event-stream "message-index")
      "Unable to install message was not printed")
 
     (message-assert


### PR DESCRIPTION
Add test for that case. Fix some other tests and update the driver.

This will help investigate cases when install fails as `post-command-hook` doesn't get debug on error or backtrace.