### PR TITLE
backtrace--print-frame was deleted in emacs 27+, use alternate.

### DIFF
--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -2407,10 +2407,17 @@ is now _disabled_ so you can continue to hopefully use Emacs. Info follows:\n\n"
       (princ arg)
       (princ "\n"))
     (princ "\nBacktrace:\n")
-    (mapbacktrace
-     (lambda (&rest args)
-       (apply 'backtrace--print-frame args))
-     #'explain-pause-report-measuring-bug)))
+    ;; emacs 27+, emacs commit 83af893fc0e7cc87c0fb0626fb48ef96e00b3f8b
+    (if (fboundp 'backtrace--print-frame)
+        (mapbacktrace
+         (lambda (&rest args)
+           (apply 'backtrace--print-frame args))
+         #'explain-pause-report-measuring-bug)
+      (require 'backtrace)
+      (declare-function backtrace-to-string "backtrace")
+      (declare-function backtrace-get-frames "backtrace")
+      (princ (backtrace-to-string (backtrace-get-frames
+                                   #'explain-pause-report-measuring-bug))))))
 
 (defvar explain-pause--current-command-record nil
   "The current command records representing what we are currently

--- a/tests/unit/test-report-bug.el
+++ b/tests/unit/test-report-bug.el
@@ -127,7 +127,7 @@
    "prints the additional args"
    (expect
     (string-match
-     "some-record\n(.*)explain-pause-command-record(.*)\nsome-string\na happy string"
+     "some-record\n.*explain-pause-command-record.*\nsome-string\na happy string"
      the-body)
     :not :to-be nil)))
 


### PR DESCRIPTION
This should have been caught via unit tests, and it did, I just didn't actually set the env-var for the unit test run correctly. I will automate that in another PR.

I decided to `(require 'backtrace)` dynamically, only when we actually need it, as it's not defined in emacs 26. In some future world when 26 support is dead (4 years from now?) I will move it to the top level requires.

The commit is https://github.com/emacs-mirror/emacs/commit/83af893fc0e7cc87c0fb0626fb48ef96e00b3f8b