### PR TITLE
Compiled lambdas should be add-hook lambda advised.

### DIFF
--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -3211,15 +3211,14 @@ of HOOK-FUNC, so we can refer to the symbol if possible."
   "Add a hook-wrapper advice for HOOK-FUNC for type HOOK-LIST, naming the
 lambda advice so we can reference it later."
   (cond
-   ((or (symbolp hook-func)
-        (byte-code-function-p hook-func))
+   ((symbolp hook-func)
     ;; directly advisable
     (advice-add hook-func :around
                 (explain-pause--generate-hook-wrapper hook-func hook-list)
                 (cons (cons 'name (format "explain-pause-wrap-hook-%s" hook-list)) nil))
     hook-func)
    (t
-    ;; ok, whateverer it is, wrap it normally and hope for the best.
+    ;; ok, whatever it is, wrap it normally and hope for the best.
     ;; it must be "funcall"-able or run-hook will have failed anyway.
     (if (and (listp hook-func)
              (listp (nth 3 hook-func))
@@ -3248,8 +3247,7 @@ can be found and removed normally."
         (hook-func (nth 1 args)))
     (when (and (seq-contains explain-pause--native-called-hooks hook-list)
                (functionp hook-func)
-               (not (symbolp hook-func))
-               (not (byte-code-function-p hook-func)))
+               (not (symbolp hook-func)))
       (setf (nth 1 args)
             (explain-pause--advice-add-hook hook-func hook-list))))
   args)

--- a/tests/cases/test-hook-add-remove.el
+++ b/tests/cases/test-hook-add-remove.el
@@ -35,8 +35,8 @@
 
 (defun it-adds-removes-symbols ()
   (let ((passed 0))
-    (add-hook 'post-command-hook 'test-hook)
 
+    (add-hook 'post-command-hook 'test-hook)
     (setq test-hook-run nil)
     (run-hooks 'post-command-hook)
     (message-assert
@@ -56,20 +56,36 @@
   (let* ((passed 0)
          (ran nil)
          (hook (lambda ()
-                 (setq ran t))))
+                 (setq ran t)))
+         (compiled-hook (byte-compile
+                         (lambda ()
+                           (setq byte-ran t)))))
+
+    (setq byte-ran nil)
 
     (add-hook 'post-command-hook hook)
+    (add-hook 'post-command-hook compiled-hook)
     (run-hooks 'post-command-hook)
+
     (message-assert
      ran
      "Lambda hook ran after adding")
 
+    (message-assert
+     byte-ran
+     "Lambda compiled hook ran after adding")
+
     (remove-hook 'post-command-hook hook)
+    (remove-hook 'post-command-hook compiled-hook)
     (setq ran nil)
+    (setq byte-ran nil)
     (run-hooks 'post-command-hook)
     (message-assert
      (not ran)
      "Lambda hook did not run after removing")
+    (message-assert
+     (not byte-ran)
+     "Lambda compiled hook did not run after removing")
 
     passed))
 


### PR DESCRIPTION
The only thing `advice-add' can actually advise are symbols. Byte code functions cannot be advised, but symbols pointing to byte code functions can be.

Add test as well.

Fixes #71.