### PR TITLE
Fix incorrect polyfill for emacs; make bytecode actually test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ find_buttercup_from_packages=$(shell $(EMACS_PACKAGES) $(EMACS_OPTS) --batch -f 
 find_set_buttercup_from_packages=$(eval BUTTERCUP_DIR:=$(find_buttercup_from_packages))$(BUTTERCUP_DIR)
 get_buttercup=$(if $(BUTTERCUP_DIR),$(BUTTERCUP_DIR),$(info Buttercup not specified; finding buttercup from emacs packages...)$(find_set_buttercup_from_packages))
 
+TARGET:=explain-pause-mode.el
+
 # all the test cases don't generate output so they need to be PHONY
 .PHONY: test case-tests $(cases) $(unit-tests) print-emacs-version
 
@@ -31,6 +33,7 @@ all: byte-compile tests
 
 byte-compile:
 	$(EMACS) $(EMACS_OPTS) -batch --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile explain-pause-mode.el
+	$(eval TARGET:=explain-pause-mode.elc)
 
 print-emacs-version:
 	@echo "Emacs version under test: " `$(EMACS) --version | head -n 1`
@@ -38,16 +41,16 @@ print-emacs-version:
 case-tests: $(cases)
 
 $(cases): %.el: print-emacs-version
-	$(EMACS) $(EMACS_OPTS) -batch -Q -f toggle-debug-on-error -l $(case-driver) -l $@ -f run-test
+	TARGET=$(TARGET) $(EMACS) $(EMACS_OPTS) -batch -Q -f toggle-debug-on-error -l $(case-driver) -l $@ -f run-test
 
 $(unit-tests): %.el: print-emacs-version
-	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l buttercup.el -l $@ -f buttercup-run
+	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l $(TARGET) -l buttercup.el -l $@ -f buttercup-run
 
 tests/unit/manual-test-command-logging.el: print-emacs-version
-	$(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l tests/unit/manual-test-command-logging.el
+	$(EMACS) $(EMACS_OPTS) -batch -Q -l $(TARGET) -l tests/unit/manual-test-command-logging.el
 
 unit-tests: tests/unit/manual-test-command-logging.el print-emacs-version
-	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l explain-pause-mode.el -l buttercup.el -f buttercup-run-discover $(ROOT_DIR)tests/unit
+	EMACSLOADPATH=$(call get_buttercup): $(EMACS) $(EMACS_OPTS) -batch -Q -l $(TARGET) -l buttercup.el -f buttercup-run-discover $(ROOT_DIR)tests/unit
 
 tests: unit-tests case-tests
 

--- a/tests/cases/driver.el
+++ b/tests/cases/driver.el
@@ -191,10 +191,9 @@ emacs is running at root of the project."
     (setq filename (symbol-file 'before-test)))
 
   (unless emacs-args
-    (setq emacs-args '("-nw" "-Q" ;; no window, no init
+    (setq emacs-args `("-nw" "-Q" ;; no window, no init
                       "-l"
-                      ;; TODO maybe make this calculate the paths..?
-                      "./explain-pause-mode.el"
+                      ,(getenv "TARGET")
                       "-l"
                       "./tests/cases/driver.el"
                       )))
@@ -221,7 +220,9 @@ emacs is running at root of the project."
 
     (setenv "SOCKET" socket-filename)
 
-    (message "Starting subemacs for test %s" filename)
+    (message "Starting subemacs for test %s with target %s"
+             filename
+             (getenv "TARGET"))
 
     ;; in case the previous tests crashed early
     (ignore-errors (delete-file socket-filename))

--- a/tests/cases/sit-for-inside-timers.el
+++ b/tests/cases/sit-for-inside-timers.el
@@ -55,6 +55,7 @@
     (m-x-run session "run-timer-interactively")
     (sleep-for 0.75)
     (send-key session "p")
+    (sleep-for 0.75)
     (call-after-test session)
     (wait-until-dead session)))
 

--- a/tests/unit/test-measurement.el
+++ b/tests/unit/test-measurement.el
@@ -201,12 +201,23 @@
 
  (it
   "advises a lambda"
-  (setq test-lambda (lambda () t))
-  (setq result-lambda (explain-pause--advice-add-hook test-lambda 'test-list))
-  (expect result-lambda
-          :not :to-equal
-          test-lambda)
-  (setq result2-lambda (explain-pause--advice-add-hook result-lambda 'test-list))
-  (expect result2-lambda
-          :to-equal
-          result-lambda)))
+  (let ((call-count 0)
+        (orig-func (symbol-function 'explain-pause--lambda-hook-wrapper)))
+    (setf (symbol-function 'explain-pause--lambda-hook-wrapper)
+          (lambda (&rest args)
+            (setq call-count (1+ call-count))))
+    (setq test-lambda (lambda () t))
+    (setq result-lambda (explain-pause--advice-add-hook test-lambda 'test-list))
+    (expect result-lambda
+            :not :to-equal
+            test-lambda)
+    (funcall result-lambda)
+    (expect call-count :to-be 1)
+    (setq call-count 0)
+    (setq result2-lambda (explain-pause--advice-add-hook result-lambda 'test-list))
+    (expect result2-lambda
+            :to-equal
+            result-lambda)
+    (funcall result2-lambda)
+    (expect call-count :to-be 1)
+    (setf (symbol-function 'explain-pause--lambda-hook-wrapper) orig-func))))


### PR DESCRIPTION
1. Fix bug in polyfill which didn't work during bytecompile
2. Actually test everything in bytecompile
3. Fix bug found during (2) where we were continually re-advising    lambda because it was bytecompiled
4. Adjust tests

Fixes #75 