### PR TITLE
Allow mode to be installed multiple times.

### DIFF
--- a/explain-pause-mode.el
+++ b/explain-pause-mode.el
@@ -3211,7 +3211,7 @@ of HOOK-FUNC, so we can refer to the symbol if possible."
       (apply hook-func args)
 
     (explain-pause--pause-call-unpause
-     (format "wrap hook %s for %s" hook-func hook-list)
+     (format "wrap hook (named wrapper) %s for %s" hook-func hook-list)
      ;; it would be nice to avoid this let but in hooks people make them
      ;; re-entrant and just call them randomly. be defensive.
      (let ((parent
@@ -3371,7 +3371,8 @@ command loop, for both the default value and all buffer local values."
            read-function
            read-variable
            completing-read))
-        (install-attempt 0))
+        (install-attempt 0)
+        (is-installed nil))
 
     (defun explain-pause-mode--install-hooks ()
       "Actually install hooks for `explain-pause-mode'."
@@ -3432,8 +3433,10 @@ command loop, for both the default value and all buffer local values."
 
     (defun explain-pause-mode--try-enable-hooks ()
       "Attempt to install `explain-pause-mode' hooks."
-      (setq install-attempt 0)
-      (explain-pause-mode--enable-hooks))
+      (unless is-installed
+        (setq is-installed t)
+        (setq install-attempt 0)
+        (explain-pause-mode--enable-hooks)))
 
     (defun explain-pause-mode--enable-hooks ()
       "Install hooks for `explain-pause-mode' if it is being run at the top of the
@@ -3445,6 +3448,7 @@ timers, etc. Otherwise, try again."
               (progn
                 (message "Unable to install `explain-pause-mode'. please report a bug to \
 github.com/lastquestion/explain-pause-mode")
+                (setq is-installed nil)
                 (setq explain-pause-mode nil))
             (let ((top-of-loop t))
               ;; do not install if we are not top of loop
@@ -3478,6 +3482,7 @@ github.com/lastquestion/explain-pause-mode")
 
     (defun explain-pause-mode--disable-hooks ()
       "Disable hooks installed by `explain-pause-mode--install-hooks'."
+      (setq is-installed nil)
       (advice-remove 'file-notify-add-watch
                      #'explain-pause--wrap-file-notify-add-watch)
 

--- a/tests/cases/install-twice.el
+++ b/tests/cases/install-twice.el
@@ -1,0 +1,72 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Test for #78. Installing twice should work.
+
+(defun before-test ()
+  t)
+
+(defun after-test ()
+  t)
+
+(defun doit ()
+  (interactive)
+  (explain-pause-mode)
+  (explain-pause-mode 1))
+
+(defun run-test ()
+  (setq session (start-test
+                 nil
+                 nil
+                 '("-f" "setup-test")))
+
+  (sleep-for 0.5)
+
+  (m-x-run session "doit")
+
+  (sleep-for 0.1)
+
+  (send-key session "a")
+
+  (sleep-for 0.5)
+
+  (eval-expr session "(explain-pause-mode 1)")
+
+  (call-after-test session)
+  (wait-until-dead session))
+
+(defun finish-test (session)
+  (let* ((passed 0)
+         (stream (reverse event-stream))
+         (first-call (find-enabled stream))
+         (second-call (find-enabled (cdr first-call))))
+    (message-assert
+     (equal (nth 5 session) "exit-test-quit-emacs")
+     "mode installed correctly")
+    (message-assert
+     (and first-call
+          (not second-call))
+     "enabled only once")
+    (kill-emacs passed)))


### PR DESCRIPTION
Once installed, calling `explain-pause-mode` to install again does nothing.

Fixes #78.