### PR TITLE
Wrap various input translation maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 * Fix `flymake` not working because `post-command-hook` did not handle compiled lambdas ([#71](https://github.com/lastquestion/explain-pause-mode/issues/71))
 * Fix `disabled-command` not working because `command-execute` calls `disabled-command-function` directly ([#73](https://github.com/lastquestion/explain-pause-mode/issues/73))
 * Fix `circe` not working because `set-process-plist` lost process command frame information ([#79](https://github.com/lastquestion/explain-pause-mode/issues/79))
+* Fix button-clicks in emacs 26 not working because input-translation keymaps are not handled ([#84](https://github.com/lastquestion/explain-pause-mode/issues/84))

--- a/tests/cases/double-trouble-hooks.el
+++ b/tests/cases/double-trouble-hooks.el
@@ -1,0 +1,63 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Verify that when a native cb is asked to be wrapped twice, it
+;;; only generates one frame.
+
+(defun before-test () t)
+
+(defun double-trouble (&rest args) t)
+
+(defun do-it ()
+  (interactive)
+  (add-hook 'post-command-hook 'double-trouble)
+  (add-hook 'post-gc-hook 'double-trouble))
+
+(defun after-test () t)
+
+;; driver code
+(defun run-test ()
+  (let ((session (start-test)))
+    (wait-until-ready session)
+    (m-x-run session "do-it")
+    (sleep-for 1.5)
+    (call-after-test session)
+    (wait-until-dead session)))
+
+(defun finish-test (session)
+  (let* ((stream (reverse event-stream))
+         (double-call (span-func stream "double-trouble"))
+         (remaining-call (span-func (cdr double-call) "double-trouble"))
+         (passed 0))
+
+    (message-assert
+     double-call
+     "double trouble called")
+
+    (message-assert-not
+     (car remaining-call)
+     "double trouble not called twice")
+
+    (kill-emacs passed)))

--- a/tests/cases/translate-maps.el
+++ b/tests/cases/translate-maps.el
@@ -1,0 +1,106 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; More tests for #84. Verify that keymap translators of all kinds
+;;; have frames both before and after
+
+(defun before-test ()
+  (define-key input-decode-map
+    [?z]
+    (lambda (&optional prompt)
+      (sit-for 0.5)
+      (send-value "z key" t)
+      [?f])))
+
+(defun more-keys ()
+  (define-key key-translation-map
+    [?d]
+    (lambda (&optional prompt)
+      (sit-for 0.1)
+      (send-value "d key" t)
+      [?d])))
+
+(defun delete-keys ()
+  (interactive)
+  (define-key input-decode-map
+    [?z]
+    nil))
+
+(defun after-test ()
+  t)
+
+(defun run-test ()
+  (setq session (start-test
+                 nil
+                 nil
+                 '("-f" "setup-test" "-f" "before-test")))
+
+  (sleep-for 0.5)
+
+  (m-x-run session "explain-pause-mode")
+  (send-key session "d")
+  (sleep-for 0.5)
+
+  (send-key session "z")
+
+  (sleep-for 1)
+
+  (eval-expr session "(more-keys)")
+
+  (sleep-for 0.5)
+  (send-key session "d")
+
+  (sleep-for 0.5)
+
+  (m-x-run session "delete-keys")
+
+  (sleep-for 0.5)
+
+  (send-key session "z")
+
+  (sleep-for 0.5)
+
+  (call-after-test session)
+  (wait-until-dead session))
+
+(defun finish-test (session)
+  (let* ((stream (reverse event-stream))
+         (z-fired (get-value stream "z key"))
+         (d-fired (get-value stream "d key"))
+         (passed 0))
+
+    (message-assert
+     z-fired
+     "pre-install map fired")
+
+    (message-assert
+     d-fired
+     "post-install map fired")
+
+    (message-assert
+     (equal (nth 5 session) "exit-test-quit-emacs")
+     "translate maps worked")
+
+    (kill-emacs passed)))

--- a/tests/cases/wrap-input-existing.el
+++ b/tests/cases/wrap-input-existing.el
@@ -1,0 +1,96 @@
+;;; -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Lin Xu
+
+;; Author: Lin Xu <lin@lastquestion.org>
+;; Version: 0.1
+;; Created: May 18, 2020
+;; Keywords: performance speed config
+;; URL: https://github.com/lastquestion/explain-pause-mode
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; In emacs 26 (but not 27), mouse-down is bound to a function that
+;;; uses sit-for to test to see if it's a "double click" or not. This
+;;; means that sit-for fires without a command-record, because
+;;; translation-maps are called before command-execute. In emacs 27+,
+;;; this was changed to record time
+;;; https://github.com/emacs-mirror/emacs/commit/3d5e31eceb9dc1fb62b2b27bcab549df3bd04ce9
+;;; Repro for #84
+
+(defun before-test ()
+  (with-current-buffer (get-buffer-create "test-buffer")
+    (insert-text-button "Test"
+                        'action 'test-click
+                        'follow-link t)
+    (goto-char 3))
+  (switch-to-buffer "test-buffer")
+
+  (setq debug-on-event nil)
+  (setq mouse-1-click-follows-link 1)
+  (define-key special-event-map [sigusr2] 'mouse-down))
+
+(defun after-test ()
+  t)
+
+(defun mouse-down ()
+  (interactive)
+  (let ((mouse-down
+         `(down-mouse-1
+           (,(selected-window)
+            ,(point)
+            (0 . 0)
+            0 ;; timestamp
+            nil
+            ,(point)
+            (,(current-column) . ;; column
+             ,(line-number-at-pos (point))) ;; line
+            nil
+            (0 . 0) ;; object-relative pixel
+            (1 . 1)))))
+    (setq unread-command-events
+          (cons mouse-down unread-command-events))))
+
+(defun blank ()
+  t)
+
+(defun run-test ()
+  (setq session (start-test
+                 nil
+                 nil
+                 '("-f" "setup-test" "-f" "before-test")))
+
+  (sleep-for 0.5)
+
+  (m-x-run session "explain-pause-mode")
+  (eval-expr session "(blank)")
+  (sleep-for 0.5)
+
+  (send-signal session 'sigusr2)
+  (sleep-for 2)
+
+  (call-after-test session)
+  (wait-until-dead session))
+
+(defun finish-test (session)
+  (let* ((stream (reverse event-stream))
+         (passed 0))
+
+    (message-assert
+     (equal (nth 5 session) "exit-test-quit-emacs")
+     "mouse click worked")
+
+    (kill-emacs passed)))

--- a/tests/unit/test-measurement.el
+++ b/tests/unit/test-measurement.el
@@ -168,9 +168,10 @@
 
 (defun test-function () t)
 (defun byte-compile-function () t)
+(defun double-trouble () t)
 
 (describe
- "explain-pause--advice-add-hook"
+ "explain-pause--advice-add-cb"
 
  (before-all
   (byte-compile 'byte-compile-function))
@@ -178,7 +179,7 @@
  (it
   "advises a symbol function and returns it"
   (expect
-   (explain-pause--advice-add-hook 'test-function 'test-list)
+   (explain-pause--advice-add-cb 'test-function 'test-list)
    :to-be
    'test-function)
 
@@ -190,7 +191,7 @@
  (it
   "advises a bytecompiled function"
   (expect
-   (explain-pause--advice-add-hook 'byte-compile-function 'test-list)
+   (explain-pause--advice-add-cb 'byte-compile-function 'test-list)
    :to-be
    'byte-compile-function)
 
@@ -202,22 +203,22 @@
  (it
   "advises a lambda"
   (let ((call-count 0)
-        (orig-func (symbol-function 'explain-pause--lambda-hook-wrapper)))
-    (setf (symbol-function 'explain-pause--lambda-hook-wrapper)
+        (orig-func (symbol-function 'explain-pause--lambda-cb-wrapper)))
+    (setf (symbol-function 'explain-pause--lambda-cb-wrapper)
           (lambda (&rest args)
             (setq call-count (1+ call-count))))
     (setq test-lambda (lambda () t))
-    (setq result-lambda (explain-pause--advice-add-hook test-lambda 'test-list))
+    (setq result-lambda (explain-pause--advice-add-cb test-lambda 'test-list))
     (expect result-lambda
             :not :to-equal
             test-lambda)
     (funcall result-lambda)
     (expect call-count :to-be 1)
     (setq call-count 0)
-    (setq result2-lambda (explain-pause--advice-add-hook result-lambda 'test-list))
+    (setq result2-lambda (explain-pause--advice-add-cb result-lambda 'test-list))
     (expect result2-lambda
             :to-equal
             result-lambda)
     (funcall result2-lambda)
     (expect call-count :to-be 1)
-    (setf (symbol-function 'explain-pause--lambda-hook-wrapper) orig-func))))
+    (setf (symbol-function 'explain-pause--lambda-cb-wrapper) orig-func))))


### PR DESCRIPTION
Input translation maps are called directly from keyboard.c, without going through command-execute. Wrap all such functions in such keymaps, both on startup, and also when new frames are created on new terminals.

Treat these in the same way as native-hooks.

Also, make explain-pause-top profile links clickable using the mouse.

Also, fix a potential bug where multiple wrappers (and thus command frames) might be created if an callback is installed in multiple keymaps or hooks.

Fixes #84.